### PR TITLE
Fixed graphical environment detection for Arch

### DIFF
--- a/Cataclysm-Ubuntu-Compiler.sh
+++ b/Cataclysm-Ubuntu-Compiler.sh
@@ -164,7 +164,7 @@ elif [[ ( "$VERSION" = 'T' ) || ( "$VERSION" = 't' ) ]]
       GRAPHICS=$(dpkg -l 2>/dev/null | grep -E "xinit|wayland" | awk '{print $2}')
   elif [ "$OS" = 'Arch' ]
     then
-      GRAPHICS=$(pacman -Q | awk '{print $1}' | grep -E "xinit\|wayland")
+      GRAPHICS=$(pacman -Q | awk '{print $1}' | grep -E "xinit|wayland")
   elif [ "$OS" = 'RPM-DNF' ]
     then
       GRAPHICS=$(dnf list installed | grep -E "xinit|wayland" | awk '{print $1}')


### PR DESCRIPTION
grep -E "xinit\|wayland" returns nothing and will always lead to prompting the user to install a graphical environment. grep -E "xinit|wayland" however will return with values if either are installed.